### PR TITLE
fix file base name validation

### DIFF
--- a/urban/hander.spec.js
+++ b/urban/hander.spec.js
@@ -154,7 +154,7 @@ describe('campaign creatives zip file upload validators', () => {
       let isValid;
 
       try {
-        isValid = await validateConversioZipFile({
+        isValid = await validateGWDZipFile({
           fileBaseName: 'gwd-test-a (1)',
           directoryToUpload: 'testUploadDirectory',
           _getFiles,

--- a/urban/handler.js
+++ b/urban/handler.js
@@ -185,7 +185,7 @@ const validateFile = async ({ fileBaseName, directoryToUpload, exporter }) => {
 };
 
 export const validateGWDZipFile = async ({
-  // fileBaseName,
+  fileBaseName,
   directoryToUpload,
   _getFiles = getFiles,
   _readRootHtmlFile = readRootHtmlFile,
@@ -198,18 +198,16 @@ export const validateGWDZipFile = async ({
     throw new VError('Zip file does not contain a root .html file');
   }
 
-  /*
   const rootHtmlFileBaseName = _(rootHtmlFile)
-      .replace(`${EXTRACT_DIRECTORY}/${fileBaseName}/`, '')
-      .split('.html')[0]
-      .split('/')[0];
+    .replace(`${EXTRACT_DIRECTORY}/${fileBaseName}/`, '')
+    .split('.html')[0]
+    .split('/')[0];
 
   if (!_.includes(fileBaseName, rootHtmlFileBaseName)) {
-      throw new VError(
-          `Zip file name '${fileBaseName}' does not contain basename '${rootHtmlFileBaseName}'`
-      );
+    throw new VError(
+      `Zip file name '${fileBaseName}' does not contain basename '${rootHtmlFileBaseName}'`
+    );
   }
-  */
 
   const rootHtmlString = _readRootHtmlFile(rootHtmlFile);
 


### PR DESCRIPTION
* The part of the validateGWDZipFile function that checks if the root HTML file base name is in the zip file base name was commented out.
* The test that checks the above-mentioned code called different function than validateGWDZipFile.